### PR TITLE
Update requirement on ocr4all_pixel_classifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,43 @@
-SHELL = /bin/bash
+SHELL = bash
 PYTHON = python
 PIP = pip
 
 DOCKER_TAG = 'ls6uniwue/ocrd_pixelclassifier_segmentation'
 
-ifndef TENSORFLOW_GPU
-	TENSORFLOW_VARIANT = tf_cpu
+# If set to 1, uses tensorflow-gpu. Requires working cuDNN setup. Default: $(TENSORFLOW_GPU)
+TENSORFLOW_GPU ?= 0
+
+ifeq ($(TENSORFLOW_GPU),1)
+TENSORFLOW_VARIANT = tf_gpu
 else
-	TENSORFLOW_VARIANT = tf_gpu
+TENSORFLOW_VARIANT = tf_cpu
 endif
+
+# BEGIN-EVAL makefile-parser --make-help Makefile
 
 help:
 	@echo ""
 	@echo "  Targets"
 	@echo ""
-	@echo "    deps         install dependencies"
-	@echo "    install      install package"
+	@echo "    deps          Install python deps via pip"
+	@echo "    deps-test     Install testing python deps via pip"
+	@echo "    install       Install"
+	@echo "    docker        Build docker image"
+	@echo "    test-cli      Test the command line tools"
+	@echo "    repo/assets   Clone OCR-D/assets to ./repo/assets"
+	@echo "    test/assets   Setup test assets"
+	@echo "    assets-clean  Remove symlinks in test/assets"
 	@echo ""
-	@echo "  Environment variables"
+	@echo "  Variables"
 	@echo ""
-	@echo "    TENSORFLOW_GPU   if set, uses tensorflow-gpu"
-	@echo "                     requires working cuDNN setup"
+	@echo "    TENSORFLOW_GPU  If set to 1, uses tensorflow-gpu. Requires working cuDNN setup. Default: $(TENSORFLOW_GPU)"
 
+# END-EVAL
 
 # Install python deps via pip
 deps:
 	$(PIP) install -r requirements.txt
-	$(PIP) install ocr4all-pixel-classifier[$(TENSORFLOW_VARIANT)]
+	$(PIP) install 'ocr4all-pixel-classifier[$(TENSORFLOW_VARIANT)]'
 
 # Install testing python deps via pip
 deps-test:
@@ -40,12 +51,11 @@ install: deps
 docker:
 	docker build -t $(DOCKER_TAG) .
 
-#TODO tests
-
 .PHONY: install deps
 
 
-test: test/assets
+# TODO tests
+# test: test/assets
 
 # Test the command line tools
 test-cli: test/assets install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ocrd>=2.0.0a1
-click
 ocr4all-pixel-classifier>=0.2.0
 numpy

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ setup(
     long_description_content_type='text/markdown',
     author='Alexander Gehrke, Christian Reul, Christoph Wick',
     author_email='alexander.gehrke@uni-wuerzburg.de, christian.reul@uni-wuerzburg.de, christoph.wick@uni-wuerzburg.de',
-    url='https://github.com/ocr-d-modul-2-segmentierung/segmentation-runner',
+    url='https://github.com/ocr-d-modul-2-segmentierung/ocrd-pixelclassifier-segmentation',
     packages=find_packages(exclude=('tests', 'docs')),
     install_requires=open("requirements.txt").read().split(),
     extras_require={
-        'tf_cpu': ['ocr4all_pixel_classifier[tf_cpu]>=0.0.1'],
-        'tf_gpu': ['ocr4all_pixel_classifier[tf_gpu]>=0.0.1'],
+        'tf_cpu': ['ocr4all_pixel_classifier[tf_cpu]>=0.2.0'],
+        'tf_gpu': ['ocr4all_pixel_classifier[tf_gpu]>=0.2.0'],
     },
     package_data={
         '': ['*.json', '*.yml', '*.yaml'],


### PR DESCRIPTION
requirements.txt says ocr4all-pixel-classifier >= 2.0 but setup.py said >= 0.0.1. Also some changes to makefile so it's properly documented and the test target disabled. Tests would help though, obviously.